### PR TITLE
Set all desktop backgrounds.

### DIFF
--- a/bing.py
+++ b/bing.py
@@ -17,8 +17,10 @@ COUNTRY_CODE = ''
 
 # Apple Script to set wallpaper
 SCRIPT = """/usr/bin/osascript<<END
-tell application "Finder"
-set desktop picture to POSIX file "%s"
+tell application "System Events"
+    tell every desktop
+        set picture to "%s"
+    end tell
 end tell
 END"""
 


### PR DESCRIPTION
In case it is of any use, this modification to the script sets all desktop backgrounds to the image (rather than just the primary).